### PR TITLE
ci: group babel packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,10 @@ updates:
       include: scope
     open-pull-requests-limit: 20
     groups:
+      babel:
+        patterns:
+          - "@babel/*"
+          - "babel-loader"
       npm:
         update-types:
           - minor


### PR DESCRIPTION
Bumping `@babel/core` and `@babel/preset-env` independently fails `npm ci` with ERESOLVE (v8 preset-env peer-requires v8 core). The npm group only covers minor/patch, so major bumps came as separate broken PRs (#142, #143).

Adds a `babel` group (`@babel/*`, `babel-loader`) with no update-type restriction so coupled bumps land in one resolvable PR. Verified locally: `npm install --dry-run @babel/core@8 @babel/preset-env@8` resolves cleanly.

After merge, close #142/#143 so dependabot recreates them as one grouped PR.